### PR TITLE
xvfb-run and Test::NeedsDisplay

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,7 @@ use warnings;
 
 use ExtUtils::MakeMaker;
 
+use Test::NeedsDisplay;
 use File::Spec;
 use Data::Dumper;
 

--- a/lib/Gtk3/WebKit.pm
+++ b/lib/Gtk3/WebKit.pm
@@ -406,6 +406,22 @@ sub import {
 
 1;
 
+=head1 INSTALLATION
+
+=head2 "Headless" Debian based systems (inc Ubuntu)
+
+If you are running an X Server (desktop environment) then you should be fine.
+If you are trying to install this on a "headless" server, then you will need a
+framebuffer display to take the place of the X server.
+
+The xvfb-run command can do this for you.
+
+With Ubuntu 12.04 LTS, you'll need these (or more recent) extra deb packages:
+
+    xvfb libgirepository1.0-dev pkg-config libgtk-3-dev libglib2.0-dev libglib2.0-0 gir1.2-webkit-3.0
+
+At which point everything should "just work".
+
 =head1 BUGS
 
 For any kind of help or support simply send a mail to the gtk-perl mailing

--- a/t/webkit.t
+++ b/t/webkit.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 
+use Test::NeedsDisplay;
 use Test::More 'no_plan';
 use Data::Dumper;
 


### PR DESCRIPTION
As suggested here:

http://blogs.perl.org/users/minty/2013/03/gtk3webkit-on-ubuntu.html#comments

I've patched the Makefile.PL and t/webkit.t to use Test::NeedsDisplay

For me, it both makes things pass without needing explicit use of xvfb-run, and also emits fewer warnings.

I've updated the POD with an Installation section as suggested and listed the debian packages I needed to install on Ubuntu 12.04 to make things work.

I confess I'm not sure how one goes about detecting if the GIR file is installed :/
