### PR TITLE
Fix installation failing if Test::NeedsDisplay is not installed

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,6 @@ use warnings;
 
 use ExtUtils::MakeMaker;
 
-use Test::NeedsDisplay;
 use File::Spec;
 use Data::Dumper;
 
@@ -22,6 +21,9 @@ sub main {
 			'Gtk3'                        => 0,
 		},
 		PREREQ_FATAL  => 1,
+		TEST_REQUIRES => {
+			'Test::NeedsDisplay'          => 0,
+		},
 
 		META_MERGE => {
 			resources => {


### PR DESCRIPTION
Tell MakeMaker about the dependency instead of just using the module.

Fixes https://rt.cpan.org/Ticket/Display.html?id=89238
